### PR TITLE
add prefix when generating default css without template

### DIFF
--- a/lib/directory-encoder.js
+++ b/lib/directory-encoder.js
@@ -79,7 +79,7 @@
 		if( this.template ){
 			css = this.template( data );
 		} else {
-			css = "." + name +
+			css = this.prefix + name +
 				" { background-image: url('" +
 				datauri +
 				"'); background-repeat: no-repeat; }";

--- a/test/directory-encoder_test.js
+++ b/test/directory-encoder_test.js
@@ -121,7 +121,7 @@
 
 		rule: function( test ) {
 			test.equal( this.encoder._css("foo", "bar"),
-				".foo { background-image: url('bar'); background-repeat: no-repeat; }" );
+				".icon-foo { background-image: url('bar'); background-repeat: no-repeat; }" );
 			test.done();
 		},
 


### PR DESCRIPTION
I think the prefix should also be honored when generating the css without a template.
