### PR TITLE
Update svg-uri-encoder.js

### DIFF
--- a/lib/svg-uri-encoder.js
+++ b/lib/svg-uri-encoder.js
@@ -24,7 +24,7 @@
 			.replace( /[\n\r]/gmi, "" )
 			.replace( /\t/gmi, " " )
 			//strip comments
-			.replace(/<\!\-\-(.*(?=\-\->))\-\->/gmi, "")
+			.replace(/<\!\-\-(.*(?=\-\->))\-\->/gmi, "");
 	};
 
 	module.exports = SvgURIEncoder;


### PR DESCRIPTION
Do not see a reason to replace all lower case quotes with \i
