### PR TITLE
Allow specification of png fallback path

### DIFF
--- a/lib/directory-encoder.js
+++ b/lib/directory-encoder.js
@@ -17,6 +17,7 @@
 		this.prefix = this.options.prefix || ".icon-";
 
 		this.options.pngfolder = this.options.pngfolder || "";
+		this.options.pngpath = this.options.pngpath || this.options.pngfolder;
 
 		this.customselectors = this.options.customselectors || {};
 		this.template = this._loadTemplate( this.options.template );

--- a/lib/png-uri-encoder.js
+++ b/lib/png-uri-encoder.js
@@ -22,7 +22,8 @@
 		//IE LTE8 cannot handle datauris that are this big. Need to make sure it just
 		//links to a file
 		if (options && (datauri.length > 32768 || options.noencodepng )) {
-			return path.join(options.pngfolder, path.basename(this.path))
+			var output_path = options.pngpath || options.pngfolder;
+			return path.join(output_path, path.basename(this.path))
 				.split( path.sep )
 				.join( "/" );
 		}

--- a/test/data-uri-encoder_test.js
+++ b/test/data-uri-encoder_test.js
@@ -134,4 +134,23 @@
 			test.done();
 		}
 	};
+	exports['PngURIEncoder3'] = {
+		setUp: function( done ) {
+			this.encoder = new PngURIEncoder( "test/files/cat.png" );
+			done();
+		},
+		tearDown: function( done ){
+			done();
+		},
+		noencode_custompath: function( test ){
+			var options = {
+				noencodepng: true,
+				pngfolder: "foo",
+				pngpath: "bar"
+			};
+
+			test.equal( this.encoder.encode(options), 'bar/cat.png' );
+			test.done();
+		}
+	};
 }());


### PR DESCRIPTION
As [discussed here](https://github.com/filamentgroup/grunticon/issues/58) some users need to have PNG fallbacks served at a different location than their path, e.g. the Rails asset pipeline.

It would be nice to allow to set URLs with this, such as `https://example.s3.amazonaws.com/`, but the split and join [here](https://github.com/filamentgroup/directory-encoder/blob/master/lib/png-uri-encoder.js#L26-L27) will break the protocol and leave you with `https:/example...`
