### PR TITLE
Add new option "extensions"

### DIFF
--- a/lib/directory-encoder.js
+++ b/lib/directory-encoder.js
@@ -18,6 +18,7 @@
 
 		this.options.pngfolder = this.options.pngfolder || "";
 		this.options.pngpath = this.options.pngpath || this.options.pngfolder;
+		this.options.extensions = this.options.extensions || [".svg", ".png"];
 
 		this.customselectors = this.options.customselectors || {};
 		this.template = this._loadTemplate( this.options.template );
@@ -46,7 +47,7 @@
 				filepath = path.join( self.input, file ),
 				extension = path.extname( file );
 
-			if( extension === ".svg" || extension === ".png" ) {
+			if( self.options.extensions.indexOf( extension ) !== -1 ) {
 				if( fs.lstatSync( filepath ).isFile() ) {
 					self._checkName(seen, file.replace( extension, '' ));
 


### PR DESCRIPTION
By default, directory-encoder encodes all `.svg` and `.png` files in the input directory. With this option you can tell directory-encoder to only encode files with specific filename extensions (e.g. by setting `extensions = [".svg"]`). The default stays `extensions = [".svg", ".png"]`.

Motivation: I have a folder that contains `.svg` files and corresponding `.png` files with identical filenames (except for the filename extension, e.g. `file.svg` and `file.png`). Without this change the `_checkName` method aborts with the error that two files with the same name exist in the input directory.

(Alternatively this could be implemented using a regex match on the filename extension or the whole filename. Please tell me if you'd prefer this or another approach.)