### PR TITLE
Support URLs as pngpath

### DIFF
--- a/lib/png-uri-encoder.js
+++ b/lib/png-uri-encoder.js
@@ -4,6 +4,7 @@
 	"use strict";
 
 	var path = require( 'path' );
+	var url = require('url');
 	var DataURIEncoder = require( './data-uri-encoder' );
 
 	function PngURIEncoder(path) {
@@ -23,9 +24,21 @@
 		//links to a file
 		if (options && (datauri.length > 32768 || options.noencodepng )) {
 			var output_path = options.pngpath || options.pngfolder;
-			return path.join(output_path, path.basename(this.path))
-				.split( path.sep )
-				.join( "/" );
+			
+			var pattern_url = /^(http:|https:|\/\/).*/;
+			var file_url = null;
+			
+			// check if output_path is a hostname
+			if (pattern_url.test(output_path)) {
+				file_url = url.resolve(output_path, path.basename(this.path));
+			}
+			else {
+				file_url = path.join(output_path, path.basename(this.path))
+						.split( path.sep )
+						.join( "/" );
+			}
+			
+			return file_url;
 		}
 
 		return datauri;

--- a/test/data-uri-encoder_test.js
+++ b/test/data-uri-encoder_test.js
@@ -174,4 +174,40 @@
 			test.done();
 		}
 	};
+	exports['PngURIEncoder4'] = {
+        setUp: function( done ) {
+        	this.encoder = new PngURIEncoder( "test/files/cat.png" );
+            	done();
+        },
+        tearDown: function( done ){
+        	done();
+        },
+        noencode_url_pngpath_http: function( test ){
+        	var options = {
+			noencodepng: true,
+			pngpath: "http://myhost.com/images/"
+		};
+
+		test.equal( this.encoder.encode(options), 'http://myhost.com/images/cat.png' );
+		test.done();
+        },
+        noencode_url_pngpath_https: function( test ){
+		var options = {
+			noencodepng: true,
+			pngpath: "https://myhost.com/images/"
+		};
+
+		test.equal( this.encoder.encode(options), 'https://myhost.com/images/cat.png' );
+		test.done();
+        },
+        noencode_url_pngpath_schemaless: function( test ){
+		var options = {
+			noencodepng: true,
+			pngpath: "//mycdn.com/images/"
+		};
+
+		test.equal( this.encoder.encode(options), '//mycdn.com/images/cat.png' );
+		test.done();
+        }
+    };
 }());


### PR DESCRIPTION
The PNG fallback images may be loaded from a subdomain or CDN. Pngpath
supports URLs in the following formats:

http://myimagehost.com/images/whatever/
https://myimagehost.com/images/whatever/
//myimagehost.com/images/whatever/